### PR TITLE
hack: disable optimizations for n_iter > 1

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -358,6 +358,8 @@ def get_free_memory(dev=None, torch_free_too=False):
         return mem_free_total
 
 def maximum_batch_area():
+    return 0
+    # See https://github.com/jug-dev/hordelib/issues/225
     global vram_state
     if vram_state == VRAMState.NO_VRAM:
         return 0


### PR DESCRIPTION
This has the practical side effect of a substantial speed increase for high vram cards, while potentially slowing doing inference for n_iter values greater than one.